### PR TITLE
docs: fix simple typo, beggining -> beginning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: c
+
+script:
+  - make
+  - make test

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ while(1) {
     do_something(str, len);
   }
 
-  /* if there are remaining bytes, move to the beggining of buffer */
+  /* if there are remaining bytes, move to the beginning of buffer */
   if (buffer_base > buffer && buffer_used > 0)
     memmove(buffer, buffer_base, buffer_used);
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All the code is in `netstring.c` and `netstring.h`, and these have no external d
 
 To parse a netstring, use `netstring_read()`.
 
-    int netstring_read(char *buffer, size_t buffer_length,
+    int netstring_read(char **buffer, size_t *buffer_length,
                        char **netstring_start, size_t *netstring_length);
 
 Reads a netstring from a `buffer` of length `buffer_length`. Writes to
@@ -38,6 +38,23 @@ values are:
     NETSTRING_ERROR_NO_COMMA      No comma was found at the end
     NETSTRING_ERROR_LEADING_ZERO  Leading zeros are not allowed
     NETSTRING_ERROR_NO_LENGTH     Length not given at start of netstring
+
+Example:
+
+    char  *str, *base = buffer;
+    size_t len,  size = bytes_read;
+
+    while(netstring_read(&base, &size, &str, &len) == 0) {
+      do_something(str, len);
+    }
+
+We can replace the comma with a null terminator when reading:
+
+    while(netstring_read(&base, &size, &str, &len) == 0) {
+      str[len] = 0;
+      puts(str);
+      str[len] = ',';   /* and optionally restore it */
+    }
 
 If you're sending messages with more than 999999999 bytes -- about 2
 GB -- then you probably should not be doing so in the form of a single

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Netstring parsing
-=================
+Netstring for C
+===============
 
 A [netstring](http://en.wikipedia.org/wiki/Netstring) is a way of encoding a sequence of bytes for transmission over a network, or for serialization. They're very easy to work with. They encode the data's length, and can be concatenated trivially. The format was [defined by D. J. Bernstein](http://cr.yp.to/proto/netstrings.txt) and is used in various software. Examples of netstrings:
 
@@ -18,7 +18,37 @@ Basic API
 
 All the code is in `netstring.c` and `netstring.h`, and these have no external dependencies. To use them, just include them in your application. Include `netstring.h` and link with the C code.
 
-### Parsing netstrings
+Creating netstrings
+-------------------
+
+You can create your netstrings manually like in this example:
+
+    sprintf(buf, "%lu:%s,", strlen(str), str);
+    
+This code provides a convenience function for creating netstrings:
+
+     size_t netstring_add(char **netstring, char *data);
+
+Here is how to use it:
+
+     char *netstring=0;  /* we must initialize it to zero */
+
+     netstring_add(&netstring, "first");
+     netstring_add(&netstring, "second");
+     netstring_add(&netstring, "third");
+
+     do_something(netstring);
+     
+     free(netstring);    /* we must free after using it */
+
+The extended version `netstring_add_ex` accepts a string length as the last argument:
+
+     size_t netstring_add_ex(char **netstring, char *data, size_t len);
+
+This allocates and creates a netstring containing the first `len` bytes of `data`. If `len` is 0 then no data will be read from `data`, and it may be null.
+
+Parsing netstrings
+------------------
 
 To parse a netstring, use `netstring_read()`.
 
@@ -61,34 +91,6 @@ GB -- then you probably should not be doing so in the form of a single
 netstring. This restriction is in place partially to protect from
 malicious or erroneous input, and partly to be compatible with
 D. J. Bernstein's reference implementation.
-
-### Creating netstrings
-
-You can create your netstrings manually like in this example:
-
-    sprintf(buf, "%lu:%s,", strlen(str), str);
-    
-This code provides a convenience function for creating netstrings:
-
-     size_t netstring_add(char **netstring, char *data);
-
-Here is how to use it:
-
-     char *netstring=0;  /* we must initialize it to zero */
-
-     netstring_add(&netstring, "first");
-     netstring_add(&netstring, "second");
-     netstring_add(&netstring, "third");
-
-     do_something(netstring);
-     
-     free(netstring);    /* we must free after using it */
-
-The extended version `netstring_add_ex` accepts a string length as the last argument:
-
-     size_t netstring_add_ex(char **netstring, char *data, size_t len);
-
-This allocates and creates a netstring containing the first `len` bytes of `data`. If `len` is 0 then no data will be read from `data`, and it may be null.
 
 Message Framing on stream-based connections (sockets, pipes...)
 ---------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -50,17 +50,23 @@ This allocates and creates a netstring containing the first `len` bytes of `data
 Parsing netstrings
 ------------------
 
-To parse a netstring, use `netstring_read()`.
+To parse a netstring use `netstring_read()`:
 
     int netstring_read(char **buffer_start, size_t *buffer_length,
                        char **netstring_start, size_t *netstring_length);
 
-Reads a netstring from a `buffer` of length `buffer_length`. Writes to
-`netstring_start` a pointer to the beginning of the string in the
-buffer, and to `netstring_length` the length of the string. Does not
-allocate any memory. If it reads successfully, then it returns 0. If
-there is an error, then the return value will be negative. The error
-values are:
+It reads a netstring from `buffer_start` of initial `buffer_length` and writes
+to `netstring_start` a pointer to the beginning of the string in the
+buffer and to `netstring_length` the length of the string. It also updates
+the `buffer_start` to the start of the next netstring item and `buffer_length`
+to the number of remaining bytes not processed in the buffer.
+
+It does not allocate any memory.
+
+### Return Value
+
+If it reads successfully then it returns 0. If there is an error then the
+return value will be negative. The error values are:
 
     NETSTRING_ERROR_TOO_LONG      More than 999999999 bytes in a field
     NETSTRING_ERROR_NO_COLON      No colon was found after the number
@@ -69,7 +75,7 @@ values are:
     NETSTRING_ERROR_LEADING_ZERO  Leading zeros are not allowed
     NETSTRING_ERROR_NO_LENGTH     Length not given at start of netstring
 
-Example:
+Usage Example:
 
     char  *str, *base = buffer;
     size_t len,  size = bytes_read;
@@ -86,8 +92,8 @@ We can replace the comma with a null terminator when reading (zero copy):
       str[len] = ',';   /* and optionally restore it */
     }
 
-If you're sending messages with more than 999999999 bytes -- about 2
-GB -- then you probably should not be doing so in the form of a single
+If you're sending messages with more than 999999999 bytes (about 2
+GB) then you probably should not be doing so in the form of a single
 netstring. This restriction is in place partially to protect from
 malicious or erroneous input, and partly to be compatible with
 D. J. Bernstein's reference implementation.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Basic API
 
 All the code is in `netstring.c` and `netstring.h`, and these have no external dependencies. To use them, just include them in your application. Include `netstring.h` and link with the C code.
 
-**Parsing netstrings**
+### Parsing netstrings
 
 To parse a netstring, use `netstring_read()`.
 
@@ -62,21 +62,17 @@ netstring. This restriction is in place partially to protect from
 malicious or erroneous input, and partly to be compatible with
 D. J. Bernstein's reference implementation.
 
-**Creating netstrings**
+### Creating netstrings
 
-To create a netstring, there are a few ways to do it. You could do something really simple like this example from [the spec](http://cr.yp.to/proto/netstrings.txt):
+You can create your netstrings manually like in this example:
 
-    if (printf("%lu:", len) < 0) barf();
-    if (fwrite(buf, 1, len, stdout) < len) barf();
-    if (putchar(',') < 0) barf();
+    sprintf(buf, "%lu:%s,", strlen(str), str);
     
-This code provides a convenience function for creating a new netstring:
+This code provides a convenience function for creating netstrings:
 
-     size_t netstring_encode_new(char **netstring, char *data, size_t len);
+     size_t netstring_add(char **netstring, char *data);
 
-This allocates and creates a netstring containing the first `len` bytes of `data`. This must be manually freed by the client. If `len` is 0 then no data will be read from `data`, and it may be null.
-
-Or with the `netstring_add` function:
+Here is how to use it:
 
      char *netstring=0;  /* we must initialize it to zero */
 
@@ -85,11 +81,14 @@ Or with the `netstring_add` function:
      netstring_add(&netstring, "third");
 
      do_something(netstring);
-     free(netstring);
+     
+     free(netstring);    /* we must free after using it */
 
 The extended version `netstring_add_ex` accepts a string length as the last argument:
 
-     int netstring_add_ex(char **list, char *str, int len);
+     size_t netstring_add_ex(char **netstring, char *data, size_t len);
+
+This allocates and creates a netstring containing the first `len` bytes of `data`. If `len` is 0 then no data will be read from `data`, and it may be null.
 
 Message Framing on stream-based connections (sockets, pipes...)
 ---------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Netstring for C
 ===============
+[![Build Status](https://travis-ci.org/liteserver/netstring-c.svg?branch=master)](https://travis-ci.org/liteserver/netstring-c)
 
 A [netstring](http://en.wikipedia.org/wiki/Netstring) is a way of encoding a sequence of bytes for transmission over a network, or for serialization. They're very easy to work with. They encode the data's length, and can be concatenated trivially. The format was [defined by D. J. Bernstein](http://cr.yp.to/proto/netstrings.txt) and is used in various software. Examples of netstrings:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All the code is in `netstring.c` and `netstring.h`, and these have no external d
 
 To parse a netstring, use `netstring_read()`.
 
-    int netstring_read(char **buffer, size_t *buffer_length,
+    int netstring_read(char **buffer_start, size_t *buffer_length,
                        char **netstring_start, size_t *netstring_length);
 
 Reads a netstring from a `buffer` of length `buffer_length`. Writes to
@@ -75,6 +75,18 @@ This code provides a convenience function for creating a new netstring:
      size_t netstring_encode_new(char **netstring, char *data, size_t len);
 
 This allocates and creates a netstring containing the first `len` bytes of `data`. This must be manually freed by the client. If `len` is 0 then no data will be read from `data`, and it may be null.
+
+Or with the `netstring_add` function:
+
+     char *netstring=0;  /* we must initialize it to zero */
+
+     netstring_add(&netstring, "first");
+     netstring_add(&netstring, "second");
+     netstring_add(&netstring, "third");
+
+     do_something(netstring);
+     free(netstring);
+
 
 Contributing
 ------------

--- a/README.md
+++ b/README.md
@@ -142,6 +142,25 @@ while(1) {
 ```
 Note: this example is lacking error checking from netstring_read function and it does not allocate memory for bigger messages.
 
+Additional Functions
+--------------------
+
+### netstring_list_size
+
+Retrieves the size of the netstring list (concatenated netstrings) discarding trailing spaces.
+
+```C
+int netstring_list_size(char *buffer, size_t size, size_t *ptotal);
+```
+
+### netstring_list_count
+
+Retrieves the number of items in a netstring list.
+
+```C
+int netstring_list_count(char *buffer, size_t size, int *pcount);
+```
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example:
       do_something(str, len);
     }
 
-We can replace the comma with a null terminator when reading:
+We can replace the comma with a null terminator when reading (zero copy):
 
     while(netstring_read(&base, &size, &str, &len) == 0) {
       str[len] = 0;
@@ -87,6 +87,9 @@ Or with the `netstring_add` function:
      do_something(netstring);
      free(netstring);
 
+The extended version `netstring_add_ex` accepts a string length as the last argument:
+
+     int netstring_add_ex(char **list, char *str, int len);
 
 Contributing
 ------------

--- a/makefile
+++ b/makefile
@@ -1,5 +1,4 @@
 CFLAGS = -O2 -Wall
-LDFLAGS= -lm 
 
 .PHONY: test clean
 

--- a/netstring.c
+++ b/netstring.c
@@ -30,10 +30,12 @@
    Example:
       if (netstring_read("3:foo,", 6, &str, &len) < 0) explode_and_die();
  */
-int netstring_read(char *buffer, size_t buffer_length,
+int netstring_read(char **pbuffer, size_t *pbuffer_length,
 		   char **netstring_start, size_t *netstring_length) {
   int i;
   size_t len = 0;
+  char *buffer = *pbuffer;
+  size_t buffer_length = *pbuffer_length;
 
   /* Write default values for outputs */
   *netstring_start = NULL; *netstring_length = 0;
@@ -64,9 +66,14 @@ int netstring_read(char *buffer, size_t buffer_length,
   /* Read the colon */
   if (buffer[i++] != ':') return NETSTRING_ERROR_NO_COLON;
   
-  /* Test for the trailing comma, and set the return values */
+  /* Test for the trailing comma */
   if (buffer[i + len] != ',') return NETSTRING_ERROR_NO_COMMA;
-  *netstring_start = &buffer[i]; *netstring_length = len;
+
+  /* Set the return values */
+  *netstring_start = &buffer[i];
+  *netstring_length = len;
+  *pbuffer = *netstring_start + len + 1;
+  *pbuffer_length = buffer_length - (i + len + 1);
 
   return 0;
 }

--- a/netstring.c
+++ b/netstring.c
@@ -109,13 +109,13 @@ size_t netstring_encode_new(char **netstring, char *data, size_t len) {
   return num_len + len + 2;
 }
   
-int netstring_add(char **list, char *str) {
+int netstring_add_ex(char **list, char *str, int len) {
   int  size_prev=0, size_next;
   char *ptr;
 
   if (list == 0 || str == 0) return 0;
 
-  size_next = strlen(str) + 12;
+  size_next = len + 12;
 
   if (*list == 0) {
     ptr = malloc(size_next);
@@ -132,4 +132,8 @@ int netstring_add(char **list, char *str) {
   sprintf(ptr, "%d:%s,", strlen(str), str);
   size_next = strlen(str);
   return size_prev + size_next;
+}
+
+int netstring_add(char **list, char *str) {
+  return netstring_add_ex(list, str, strlen(str));
 }

--- a/netstring.c
+++ b/netstring.c
@@ -78,7 +78,7 @@ int netstring_read(char **pbuffer, size_t *pbuffer_length,
 }
 
 /* Retrieves the size of the concatenated netstrings */
-int netstring_list_size(char *buffer, int size, size_t *ptotal) {
+int netstring_list_size(char *buffer, size_t size, size_t *ptotal) {
   char  *str, *base = buffer;
   size_t len,  remaining = size;
   int rc;
@@ -92,7 +92,7 @@ int netstring_list_size(char *buffer, int size, size_t *ptotal) {
 }
 
 /* Retrieves the number of concatenated netstrings */
-int netstring_list_count(char *buffer, int size, int *pcount) {
+int netstring_list_count(char *buffer, size_t size, int *pcount) {
   char  *str, *base = buffer;
   size_t len,  remaining = size;
   int rc, count = 0;

--- a/netstring.c
+++ b/netstring.c
@@ -77,6 +77,35 @@ int netstring_read(char **pbuffer, size_t *pbuffer_length,
   return 0;
 }
 
+/* Retrieves the size of the concatenated netstrings */
+int netstring_list_size(char *buffer, int size, size_t *ptotal) {
+  char  *str, *base = buffer;
+  size_t len,  remaining = size;
+  int rc;
+
+  while( remaining>0 && (rc=netstring_read(&base, &remaining, &str, &len))==0 ){
+  }
+
+  if( rc==NETSTRING_ERROR_NO_LENGTH || rc==NETSTRING_ERROR_TOO_SHORT ) rc = 0;
+  *ptotal = size - remaining;
+  return rc;
+}
+
+/* Retrieves the number of concatenated netstrings */
+int netstring_list_count(char *buffer, int size, int *pcount) {
+  char  *str, *base = buffer;
+  size_t len,  remaining = size;
+  int rc, count = 0;
+
+  while( remaining>0 && (rc=netstring_read(&base, &remaining, &str, &len))==0 ){
+    count++;
+  }
+
+  if( rc==NETSTRING_ERROR_NO_LENGTH || rc==NETSTRING_ERROR_TOO_SHORT ) rc = 0;
+  *pcount = count;
+  return rc;
+}
+
 /* count the number of digits (base 10) in a positive integer */
 int numdigits(size_t len) {
   int n = 1;

--- a/netstring.c
+++ b/netstring.c
@@ -31,7 +31,7 @@
       if (netstring_read("3:foo,", 6, &str, &len) < 0) explode_and_die();
  */
 int netstring_read(char **pbuffer, size_t *pbuffer_length,
-		   char **netstring_start, size_t *netstring_length) {
+                   char **netstring_start, size_t *netstring_length) {
   int i;
   size_t len = 0;
   char *buffer = *pbuffer;
@@ -108,9 +108,10 @@ size_t netstring_encode_new(char **netstring, char *data, size_t len) {
   *netstring = ns;
   return num_len + len + 2;
 }
-  
-int netstring_add_ex(char **list, char *str, int len) {
-  int  size_prev=0, size_next;
+
+/* returns the netrstring size not including the null terminator */
+size_t netstring_add_ex(char **list, char *str, size_t len) {
+  size_t size_prev=0, size_next;
   char *ptr;
 
   if (list == 0 || str == 0) return 0;
@@ -130,10 +131,10 @@ int netstring_add_ex(char **list, char *str, int len) {
   }
 
   sprintf(ptr, "%d:%s,", strlen(str), str);
-  size_next = strlen(str);
+  size_next = strlen(ptr);
   return size_prev + size_next;
 }
 
-int netstring_add(char **list, char *str) {
+size_t netstring_add(char **list, char *str) {
   return netstring_add_ex(list, str, strlen(str));
 }

--- a/netstring.c
+++ b/netstring.c
@@ -109,3 +109,27 @@ size_t netstring_encode_new(char **netstring, char *data, size_t len) {
   return num_len + len + 2;
 }
   
+int netstring_add(char **list, char *str) {
+  int  size_prev=0, size_next;
+  char *ptr;
+
+  if (list == 0 || str == 0) return 0;
+
+  size_next = strlen(str) + 12;
+
+  if (*list == 0) {
+    ptr = malloc(size_next);
+    if (ptr == 0) return 0;
+    *list = ptr;
+  } else {
+    size_prev = strlen(*list);
+    ptr = realloc(*list, size_prev + size_next);
+    if (ptr == 0) return 0;
+    *list = ptr;
+    ptr += size_prev;
+  }
+
+  sprintf(ptr, "%d:%s,", strlen(str), str);
+  size_next = strlen(str);
+  return size_prev + size_next;
+}

--- a/netstring.h
+++ b/netstring.h
@@ -11,6 +11,9 @@ int netstring_read(char **buffer_start, size_t *buffer_length,
 
 size_t netstring_buffer_size(size_t data_length);
 
+int netstring_list_size(char *buffer, int size, size_t *ptotal);
+int netstring_list_count(char *buffer, int size, int *pcount);
+
 /* Errors that can occur during netstring parsing */
 #define NETSTRING_ERROR_TOO_LONG     -1
 #define NETSTRING_ERROR_NO_COLON     -2

--- a/netstring.h
+++ b/netstring.h
@@ -11,8 +11,8 @@ int netstring_read(char **buffer_start, size_t *buffer_length,
 
 size_t netstring_buffer_size(size_t data_length);
 
-int netstring_list_size(char *buffer, int size, size_t *ptotal);
-int netstring_list_count(char *buffer, int size, int *pcount);
+int netstring_list_size(char *buffer, size_t size, size_t *ptotal);
+int netstring_list_count(char *buffer, size_t size, int *pcount);
 
 /* Errors that can occur during netstring parsing */
 #define NETSTRING_ERROR_TOO_LONG     -1

--- a/netstring.h
+++ b/netstring.h
@@ -6,8 +6,6 @@
 size_t netstring_add(char **netstring, char *data);
 size_t netstring_add_ex(char **netstring, char *data, size_t len);
 
-size_t netstring_encode_new(char **netstring, char *data, size_t len);
-
 int netstring_read(char **buffer_start, size_t *buffer_length,
                    char **netstring_start, size_t *netstring_length);
 

--- a/netstring.h
+++ b/netstring.h
@@ -3,8 +3,8 @@
 
 #include <string.h>
 
-int netstring_add(char **list, char *str);
-int netstring_add_ex(char **list, char *str, int len);
+size_t netstring_add(char **netstring, char *data);
+size_t netstring_add_ex(char **netstring, char *data, size_t len);
 
 size_t netstring_encode_new(char **netstring, char *data, size_t len);
 

--- a/netstring.h
+++ b/netstring.h
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-int netstring_read(char *buffer, size_t buffer_length,
+int netstring_read(char **pbuffer, size_t *pbuffer_length,
 		   char **netstring_start, size_t *netstring_length);
 
 size_t netstring_buffer_size(size_t data_length);

--- a/netstring.h
+++ b/netstring.h
@@ -3,12 +3,15 @@
 
 #include <string.h>
 
-int netstring_read(char **pbuffer, size_t *pbuffer_length,
-		   char **netstring_start, size_t *netstring_length);
-
-size_t netstring_buffer_size(size_t data_length);
+int netstring_add(char **list, char *str);
+int netstring_add_ex(char **list, char *str, int len);
 
 size_t netstring_encode_new(char **netstring, char *data, size_t len);
+
+int netstring_read(char **buffer_start, size_t *buffer_length,
+                   char **netstring_start, size_t *netstring_length);
+
+size_t netstring_buffer_size(size_t data_length);
 
 /* Errors that can occur during netstring parsing */
 #define NETSTRING_ERROR_TOO_LONG     -1

--- a/testsuite.c
+++ b/testsuite.c
@@ -119,11 +119,23 @@ void test_netstring_encode_new(void) {
   free(ns);
 }  
 
+void test_netstring_add(void) {
+  char *list=0;
+
+  netstring_add(&list, "first");
+  netstring_add(&list, "second");
+  netstring_add(&list, "third");
+  assert(strcmp(list, "5:first,6:second,5:third,") == 0);
+  free(list);
+
+}
+
 int main(void) {
   printf("Running test suite...\n");
   test_netstring_read();
   test_netstring_buffer_size();
   test_netstring_encode_new();
+  test_netstring_add();
   printf("All tests passed!\n");
   return 0;
 }

--- a/testsuite.c
+++ b/testsuite.c
@@ -119,13 +119,35 @@ void test_netstring_encode_new(void) {
   free(ns);
 }  
 
+void test_netstring_add_ex(void) {
+  char *ns=0; size_t bytes;
+
+  bytes = netstring_add_ex(&ns, "foo", 3);
+  assert(ns != NULL); assert(strncmp(ns, "3:foo,", 6) == 0); assert(bytes == 6);
+  free(ns); ns = 0;
+
+  bytes = netstring_add_ex(&ns, NULL, 0);
+  assert(ns != NULL); assert(strncmp(ns, "0:,", 3) == 0); assert(bytes == 3);
+  free(ns); ns = 0;
+
+  bytes = netstring_add_ex(&ns, "hello world!", 12); assert(bytes == 16);
+  assert(ns != NULL); assert(strncmp(ns, "12:hello world!,", 16) == 0);
+  free(ns); ns = 0;
+
+  bytes = netstring_add_ex(&ns, "hello world!", 5); assert(bytes == 8);
+  puts(ns);
+  assert(ns != NULL); assert(strncmp(ns, "5:hello,", 8) == 0);
+  free(ns); ns = 0;
+}
+
 void test_netstring_add(void) {
   char *list=0;
 
   netstring_add(&list, "first");
   netstring_add(&list, "second");
   netstring_add(&list, "third");
-  assert(strcmp(list, "5:first,6:second,5:third,") == 0);
+  netstring_add(&list, "");
+  assert(strcmp(list, "5:first,6:second,5:third,0:,") == 0);
   free(list);
 
 }
@@ -135,6 +157,7 @@ int main(void) {
   test_netstring_read();
   test_netstring_buffer_size();
   test_netstring_encode_new();
+  test_netstring_add_ex();
   test_netstring_add();
   printf("All tests passed!\n");
   return 0;

--- a/testsuite.c
+++ b/testsuite.c
@@ -9,6 +9,7 @@
 /* Good examples */
 char ex1[] = "12:hello world!,";
 char ex2[] = "3:foo,0:,3:bar,";
+char exb[] = "3:foo,0:,3:bar,  ";
 
 /* Bad examples */
 char ex3[] = "12:hello world! "; /* No comma */
@@ -94,6 +95,26 @@ void test_netstring_read(void) {
   assert(retval == NETSTRING_ERROR_NO_LENGTH);
 }
 
+void test_netstring_list_size(void) {
+  size_t size=0;
+  assert(netstring_list_size(ex1, strlen(ex1), &size) == 0);
+  assert(size == strlen(ex1));
+  assert(netstring_list_size(ex2, strlen(ex2), &size) == 0);
+  assert(size == strlen(ex2));
+  assert(netstring_list_size(exb, strlen(exb), &size) == 0);
+  assert(size == strlen(ex2));
+}
+
+void test_netstring_list_count(void) {
+  int count=0;
+  assert(netstring_list_count(ex1, strlen(ex1), &count) == 0);
+  assert(count == 1);
+  assert(netstring_list_count(ex2, strlen(ex2), &count) == 0);
+  assert(count == 3);
+  assert(netstring_list_count(exb, strlen(exb), &count) == 0);
+  assert(count == 3);
+}
+
 void test_netstring_buffer_size(void) {
   assert(netstring_buffer_size(0) == 3);
   assert(netstring_buffer_size(1) == 4);
@@ -138,6 +159,8 @@ void test_netstring_add(void) {
 int main(void) {
   printf("Running test suite...\n");
   test_netstring_read();
+  test_netstring_list_size();
+  test_netstring_list_count();
   test_netstring_buffer_size();
   test_netstring_add_ex();
   test_netstring_add();

--- a/testsuite.c
+++ b/testsuite.c
@@ -21,62 +21,75 @@ char ex9[] = ":what's up";		  /* No number */
 
 
 void test_netstring_read(void) {
-  char *netstring;
+  char  *base;
+  size_t base_len;
+  char  *netstring;
   size_t netstring_len;
   int retval;
 
   /* ex1: hello world */
-  retval = netstring_read(ex1, strlen(ex1), &netstring, &netstring_len);
+  base = ex1; base_len = strlen(ex1);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 12); assert(strncmp(netstring, "hello world!", 12) == 0);
+  assert(base == ex1 + strlen(ex1)); assert(base_len == 0);
   assert(retval == 0);
 
 
   /* ex2: three netstrings, concatenated. */
 
-  retval = netstring_read(ex2, strlen(ex2), &netstring, &netstring_len);
+  base = ex2; base_len = strlen(ex2);
+
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 3); assert(strncmp(netstring, "foo", 3) == 0);
   assert(retval == 0);
 
-  retval = netstring_read(netstring+netstring_len+1, 9, &netstring, &netstring_len);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(retval == 0);
 
-  retval = netstring_read(netstring+netstring_len+1, 6, &netstring, &netstring_len);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 3); assert(strncmp(netstring, "bar", 3) == 0);
-  assert(retval == 0);
+  assert(retval == 0); assert(base_len == 0);
 
 
   /* ex3: no comma */
-  retval = netstring_read(ex3, strlen(ex3), &netstring, &netstring_len);
+  base = ex3; base_len = strlen(ex3);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_NO_COMMA);
 
   /* ex4: too short */
-  retval = netstring_read(ex4, strlen(ex4), &netstring, &netstring_len);
+  base = ex4; base_len = strlen(ex4);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_TOO_SHORT);
 
   /* ex5: leading zero */
-  retval = netstring_read(ex5, strlen(ex5), &netstring, &netstring_len);
+  base = ex5; base_len = strlen(ex5);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_LEADING_ZERO);
 
   /* ex6: too long */
-  retval = netstring_read(ex6, strlen(ex6), &netstring, &netstring_len);
+  base = ex6; base_len = strlen(ex6);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_TOO_LONG);
 
   /* ex7: no colon */
-  retval = netstring_read(ex7, strlen(ex7), &netstring, &netstring_len);
+  base = ex7; base_len = strlen(ex7);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_NO_COLON);
 
   /* ex8: no number or colon */
-  retval = netstring_read(ex8, strlen(ex8), &netstring, &netstring_len);
+  base = ex8; base_len = strlen(ex8);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_NO_LENGTH);
 
   /* ex9: no number */
-  retval = netstring_read(ex9, strlen(ex9), &netstring, &netstring_len);
+  base = ex9; base_len = strlen(ex9);
+  retval = netstring_read(&base, &base_len, &netstring, &netstring_len);
   assert(netstring_len == 0); assert(netstring == NULL);
   assert(retval == NETSTRING_ERROR_NO_LENGTH);
 }

--- a/testsuite.c
+++ b/testsuite.c
@@ -103,22 +103,6 @@ void test_netstring_buffer_size(void) {
   assert(netstring_buffer_size(12345) == 12345 + 5 + 2);
 }
 
-void test_netstring_encode_new(void) {
-  char *ns; size_t bytes;
-
-  bytes = netstring_encode_new(&ns, "foo", 3);
-  assert(ns != NULL); assert(strncmp(ns, "3:foo,", 6) == 0); assert(bytes == 6);
-  free(ns);
-
-  bytes = netstring_encode_new(&ns, NULL, 0);
-  assert(ns != NULL); assert(strncmp(ns, "0:,", 3) == 0); assert(bytes == 3);
-  free(ns);
-
-  bytes = netstring_encode_new(&ns, "hello world!", 12); assert(bytes == 16);
-  assert(ns != NULL); assert(strncmp(ns, "12:hello world!,", 16) == 0);
-  free(ns);
-}  
-
 void test_netstring_add_ex(void) {
   char *ns=0; size_t bytes;
 
@@ -135,7 +119,6 @@ void test_netstring_add_ex(void) {
   free(ns); ns = 0;
 
   bytes = netstring_add_ex(&ns, "hello world!", 5); assert(bytes == 8);
-  puts(ns);
   assert(ns != NULL); assert(strncmp(ns, "5:hello,", 8) == 0);
   free(ns); ns = 0;
 }
@@ -156,7 +139,6 @@ int main(void) {
   printf("Running test suite...\n");
   test_netstring_read();
   test_netstring_buffer_size();
-  test_netstring_encode_new();
   test_netstring_add_ex();
   test_netstring_add();
   printf("All tests passed!\n");


### PR DESCRIPTION
There is a small typo in README.md.

Should read `beginning` rather than `beggining`.

